### PR TITLE
[FEAT] 게시글에서 유저 프로필 이미지 가져오기(#45)

### DIFF
--- a/backend/src/main/java/com/example/backend/post/PostResponse.java
+++ b/backend/src/main/java/com/example/backend/post/PostResponse.java
@@ -2,6 +2,7 @@ package com.example.backend.post;
 
 import com.example.backend.comment.CommentResponse;
 import com.example.backend.post_image.PostImageResponse;
+import com.example.backend.user.User;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
@@ -39,7 +40,8 @@ public class PostResponse {
     private List<PostImageResponse> images = new ArrayList<>();
     private int view;
     private Long loginId;
-    public PostResponse(Long postId, Long userId, Long categoryId, String nickname, String title, String content, int likeCount, int commentCount, int scrapCount, boolean isEdited, boolean isScrapped, boolean isLiked, LocalDateTime createdDate, LocalDateTime modifiedDate, List<CommentResponse> comments, List<PostImageResponse> images, int view, Long loginId) {
+    private String profile_url;
+    public PostResponse(Long postId, Long userId, Long categoryId, String nickname, String title, String content, int likeCount, int commentCount, int scrapCount, boolean isEdited, boolean isScrapped, boolean isLiked, LocalDateTime createdDate, LocalDateTime modifiedDate, List<CommentResponse> comments, List<PostImageResponse> images, int view, Long loginId, String profile_url) {
         this.postId = postId;
         this.userId = userId;
         this.categoryId = categoryId;
@@ -58,9 +60,10 @@ public class PostResponse {
         this.images = images;
         this.view = view;
         this.loginId = loginId;
+        this.profile_url = profile_url;
     }
 
-    public static PostResponse toDto(Post post, boolean isScrapped, boolean isLiked, List<CommentResponse> comments, List<PostImageResponse> images, Long loginId) {
+    public static PostResponse toDto(Post post, boolean isScrapped, boolean isLiked, List<CommentResponse> comments, List<PostImageResponse> images, User user) {
         return new PostResponse(
                 post.getId(),
                 post.getUser().getId(),
@@ -79,7 +82,8 @@ public class PostResponse {
                 comments,
                 images,
                 post.getView(),
-                loginId
+                user.getId(),
+                user.getProfile_url()
         );
     }
 }

--- a/backend/src/main/java/com/example/backend/post/PostService.java
+++ b/backend/src/main/java/com/example/backend/post/PostService.java
@@ -75,11 +75,12 @@ public class PostService {
                 }
             }
         }
-        return PostResponse.toDto(savedPost, false, false,null, imageResponses, null);
+        return PostResponse.toDto(savedPost, false, false,null, imageResponses, user);
     }
     @Transactional(readOnly = true)
     public PostResponse getPostById(Long postId, Long loginId) {
         Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("Invalid post ID"));
+        User user = userRepository.findById(loginId).orElseThrow(() -> new IllegalArgumentException("Invalid user ID"));
         Boolean isLiked = postLikeService.isLiked(loginId, postId);
         Boolean isScrapped = postScrapService.isScrapped(loginId, postId);
 
@@ -117,7 +118,7 @@ public class PostService {
             redisDao.setValues(redisKey, String.valueOf(views));
         }
         post.setView(views);
-        return PostResponse.toDto(post, isScrapped, isLiked, commentResponses, imageResponses, loginId);
+        return PostResponse.toDto(post, isScrapped, isLiked, commentResponses, imageResponses, user);
     }
 
     @Transactional(readOnly = true)

--- a/frontend/src/pages/post/Post.jsx
+++ b/frontend/src/pages/post/Post.jsx
@@ -147,9 +147,7 @@ export default function Post() {
       <div className="post__parent">
       <div className="post__container">
           <div className="post__userInfo">
-            <img
-              src="https://i.ibb.co/j6t0z2T/Kakao-Talk-20230512-090604281.jpg"
-            />
+            <img src={post.profile_url} />
             <div className="post__info">
               <div className="post__nickname">{post.nickname}</div>
               <div className="post__date">


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #45

## 📝작업 내용

> 프론트 - 게시글에서 유저 프로필 이미지 컬럼(profile_url) 사용해 가져오기
> 백엔드  - post 응답 시 프로필 이미지 컬럼도 가져오도록 변경

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/5f1faa74-29d3-4350-92c1-4bc0306b0fcc)
DB에 있는 profile_url을 잘 가져오고, 이미지 변경 시에도 잘 적용되는 걸 확인할 수 있습니다.

## 💬리뷰 요구사항(선택)

