### PR TITLE
[FEAT] 게시글 상세 페이지 프론트 수정(#67)

### DIFF
--- a/frontend/src/components/post/CommentItem.jsx
+++ b/frontend/src/components/post/CommentItem.jsx
@@ -108,7 +108,6 @@ export default function CommentItem({ item, postId, postWriter }) {
         await axios.post(`http://localhost:8080/comment/${commentId}/like`, {}, {
           withCredentials: true, // 쿠키를 포함하여 서버로 요청을 보냄
         });
-        
         window.location.reload();
       }
     } catch (err) {
@@ -156,9 +155,11 @@ export default function CommentItem({ item, postId, postWriter }) {
               </button>
             </li>
             <li>
-              <button onClick={(event) => likeComment(event, item.commentId)}>
-                추천
-              </button>
+              {!item.isDeleted && (
+                  <button onClick={(event) => likeComment(event, item.commentId)}>
+                    추천
+                  </button>
+              )}
             </li>
           </>
         )}
@@ -225,9 +226,11 @@ export default function CommentItem({ item, postId, postWriter }) {
                   </button>
                 </li>
                 <li>
-                  <button onClick={(event) => likeComment(event, child.commentId)}>
-                    추천
-                  </button>
+                  {!child.isDeleted && (
+                      <button onClick={(event) => likeComment(event, child.commentId)}>
+                        추천
+                      </button>
+                  )}
                 </li>
               </>
           )}

--- a/frontend/src/pages/post/Post.jsx
+++ b/frontend/src/pages/post/Post.jsx
@@ -13,7 +13,6 @@ export default function Post() {
   const [post, setPost] = useState(location.state || null);
   const [commentInput, setCommentInput] = useState("");
 
-
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -31,14 +30,14 @@ export default function Post() {
           setCategory(categoryResponse.data);
         }
       } catch (err) {
-        console.log('Error fetching data:', err);
+        navigate("/jwt-login/login");
       }
     };
     fetchData();
   }, [postId]);
 
   if (!post) {
-    return <div>Loading...</div>; // 로딩 중 메시지
+    return <div>Loading...</div>;
   }
 
   const likePost = async () => {
@@ -46,12 +45,12 @@ export default function Post() {
       alert("내가 쓴 글은 추천할 수 없습니다.");
       return;
     }
-  
+
     if (post.isLiked) {
       alert("이미 이 글을 추천하셨습니다.");
       return;
     }
-  
+
     if (window.confirm("이 글을 추천하시겠습니까?")) {
       try {
         await axios.post(`http://localhost:8080/post/${postId}/like`, {}, {
@@ -63,27 +62,27 @@ export default function Post() {
       }
     }
   };
-  
+
   const scrapPost = async () => {
     if (post.loginId === post.userId) {
       alert("내가 쓴 글은 스크랩할 수 없습니다.");
       return;
     }
-  
+
     const confirmMessage = post.isScrapped
       ? "이 글의 스크랩을 취소하시겠습니까?"
       : "이 글을 스크랩하시겠습니까?";
-    
+
     if (window.confirm(confirmMessage)) {
       const endpoint = post.isScrapped
         ? `http://localhost:8080/post/${postId}/unscrap`
         : `http://localhost:8080/post/${postId}/scrap`;
-  
+
       try {
         await axios.post(endpoint, {}, {
           withCredentials: true
         });
-        
+
         window.location.reload();
       } catch (err) {
         console.error("Error scrapping post:", err);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #67

## 📝작업 내용

> 삭제된 댓글 좋아요 막기, 로그인 하지 않은 유저의 상세 화면 처리(로그인 창으로 이동)

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/44dd805f-25c6-4c47-afe7-ee6ce3826b77)

## 💬리뷰 요구사항(선택)

