### PR TITLE
[FEAT] 댓글, 대댓글에 유저의 프로필 사진 적용하기

### DIFF
--- a/backend/src/main/java/com/example/backend/comment/CommentResponse.java
+++ b/backend/src/main/java/com/example/backend/comment/CommentResponse.java
@@ -28,8 +28,9 @@ public class CommentResponse {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM/dd HH:mm", timezone = "Asia/Seoul")
     private LocalDateTime  modifiedDate;
     private Long loginId;
+    private String profile_url;
 
-    public CommentResponse(Long commentId, Long userId, Long postId, Long parentId, List<CommentResponse> children, String nickname, String content, int likeCount, boolean isDeleted, boolean isEdited, LocalDateTime createdDate, LocalDateTime modifiedDate, Long loginId) {
+    public CommentResponse(Long commentId, Long userId, Long postId, Long parentId, List<CommentResponse> children, String nickname, String content, int likeCount, boolean isDeleted, boolean isEdited, LocalDateTime createdDate, LocalDateTime modifiedDate, Long loginId, String profile_url) {
         this.commentId = commentId;
         this.userId = userId;
         this.postId = postId;
@@ -43,6 +44,7 @@ public class CommentResponse {
         this.createdDate = createdDate;
         this.modifiedDate = modifiedDate;
         this.loginId = loginId;
+        this.profile_url = profile_url;
     }
 
     public static CommentResponse toDto(Comment comment, List<CommentResponse> children, Long loginId) {
@@ -59,7 +61,8 @@ public class CommentResponse {
                 comment.isEdited(),
                 comment.getCreatedDate(),
                 comment.getModifiedDate(),
-                loginId
+                loginId,
+                comment.getUser().getProfile_url()
         );
     }
 }

--- a/frontend/src/components/post/CommentItem.jsx
+++ b/frontend/src/components/post/CommentItem.jsx
@@ -120,7 +120,7 @@ export default function CommentItem({ item, postId, postWriter }) {
   return (
     <div className="comment_parent">
       <div className="commentInfo">
-        <img src="https://cf-fpi.everytime.kr/0.png" />
+        <img src={item.profile_url} />
         <div className="comment__nickname">
           {item.nickname}
           {postWriter === item.userId && <span>(글쓴이)</span>} {/* userId와 loginId가 같으면 "(글쓴이)" 표시 */}
@@ -198,7 +198,7 @@ export default function CommentItem({ item, postId, postWriter }) {
       {item.children && item.children.map((child) => (
     <div key={child.commentId} className="reply">
       <div className="commentInfo">
-        <img src="https://cf-fpi.everytime.kr/0.png" alt="User"/>
+        <img src={child.profile_url} />
         <div className="comment__nickname">
           {child.nickname}
           {postWriter === child.userId && <span>(글쓴이)</span>}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

>  #86 

## 📝작업 내용

- 댓글, 대댓글에서 유저의 프로필 사진 적용하도록 프백 구현하였습니다.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/8fc570a0-9cbd-47fc-a617-4e15f5340713)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
